### PR TITLE
Update web socket to handle binary data.

### DIFF
--- a/lib/platform/server.dart
+++ b/lib/platform/server.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:seltzer/src/context.dart';
@@ -13,7 +14,7 @@ export 'package:seltzer/seltzer.dart';
 /// This is appropriate for clients running in the VM on the command line.
 void useSeltzerInTheServer() {
   setPlatform(const ServerSeltzerHttp());
-  setWebSocketProvider(() => new ServerSeltzerWebSocket());
+  setWebSocketProvider((String url) => new ServerSeltzerWebSocket(url));
 }
 
 /// An implementation of [SeltzerHttp] that works within the browser.
@@ -49,37 +50,86 @@ class _IOSeltzerHttpResponse implements SeltzerHttpResponse {
 
 /// A [SeltzerWebSocket] implementation for the dart vm.
 class ServerSeltzerWebSocket implements SeltzerWebSocket {
-  final StreamController<String> _onDataController =
-      new StreamController<String>.broadcast();
+  final Completer<Null> _onOpenCompleter = new Completer<Null>();
+  final Completer<Null> _onCloseCompleter = new Completer<Null>();
+  final StreamController<SeltzerMessage> _onMessageController =
+      new StreamController<SeltzerMessage>.broadcast();
 
-  StreamSubscription _dataSubscription;
+  /// This is needed because dart:io WebSockets don't offer a reliable method
+  /// for determining when a socket has closed. With this implementation,
+  /// [onClose] will emit immediately after calling [close] while the underlying
+  /// web socket closes its actual connection in the background.
+  bool _isOpen = false;
+  StreamSubscription _messageSubscription;
   WebSocket _webSocket;
 
-  @override
-  Stream<String> get onData => _onDataController.stream;
-
-  @override
-  Future open(String url) async {
-    await close();
-    _webSocket = await WebSocket.connect(url);
-    _dataSubscription = _webSocket.listen(_onDataController.add);
+  /// Creates a new server web sock connected to the remote peer at [url].
+  ServerSeltzerWebSocket(String url) {
+    WebSocket.connect(url).then((WebSocket webSocket) {
+      _webSocket = webSocket;
+      _messageSubscription = _webSocket.listen((payload) {
+        _onMessageController.add(new _ServerSeltzerMessage(payload));
+      });
+      _isOpen = true;
+      _onOpenCompleter.complete();
+    });
   }
 
   @override
-  Future close([int code, String reason]) async {
-    _dataSubscription?.cancel();
-    _webSocket?.close(code, reason);
+  Stream<SeltzerMessage> get onMessage => _onMessageController.stream;
+
+  @override
+  Stream<Null> get onOpen => _onOpenCompleter.future.asStream();
+
+  @override
+  Stream<Null> get onClose => _onCloseCompleter.future.asStream();
+
+  @override
+  Future<Null> close([int code, String reason]) async {
+    _errorIfClosed();
+    _isOpen = false;
+    _messageSubscription.cancel();
+    _webSocket.close(code, reason);
+    _onCloseCompleter.complete();
   }
 
   @override
-  Future sendString(String data) async {
-    _ensureIsOpen();
+  Future<Null> sendString(String data) async {
+    _errorIfClosed();
     _webSocket.add(data);
   }
 
-  void _ensureIsOpen() {
-    if (_webSocket == null) {
-      throw new StateError("Socket is not open.");
+  @override
+  Future<Null> sendBytes(ByteBuffer data) async {
+    _errorIfClosed();
+    _webSocket.add(data.asInt8List());
+  }
+
+  void _errorIfClosed() {
+    if (!_isOpen) {
+      throw new StateError("Socket is closed");
     }
   }
+}
+
+class _ServerSeltzerMessage implements SeltzerMessage {
+  final Object _payload;
+
+  _ServerSeltzerMessage(this._payload);
+
+  @override
+  Future<ByteBuffer> readAsArrayBuffer() async {
+    if (_payload is ByteBuffer) {
+      return _payload;
+    } else if (_payload is TypedData) {
+      TypedData data = _payload;
+      return data.buffer;
+    } else {
+      // _payload must be String.
+      return new Uint8List.fromList(new Utf8Encoder().convert(_payload)).buffer;
+    }
+  }
+
+  @override
+  Future<String> readAsString() async => _payload.toString();
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -10,7 +10,7 @@ import 'package:seltzer/src/interface.dart';
 SeltzerHttp _platform;
 
 // A Provider of [SeltzerWebSocket] instances.
-typedef SeltzerWebSocket _WebSocketProvider();
+typedef SeltzerWebSocket _WebSocketProvider(String url);
 
 // The current configured _WebSocketProvider.
 
@@ -46,7 +46,7 @@ void setWebSocketProvider(_WebSocketProvider provider) {
 }
 
 /// Internal method
-SeltzerWebSocket createWebSocket() => _createWebSocket();
+SeltzerWebSocket createWebSocket(String url) => _createWebSocket(url);
 
 /// Internal method: Returns the top-level instance.
 SeltzerHttp getPlatform() => _seltzer;

--- a/test/platform/web_socket/common_utils.dart
+++ b/test/platform/web_socket/common_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:seltzer/seltzer.dart';
 import 'package:test/test.dart';
 
@@ -9,20 +11,66 @@ void runPlatformTests() {
     SeltzerWebSocket webSocket;
 
     setUp(() async {
-      webSocket = createWebSocket();
-      await webSocket.open(_echoUrl);
+      webSocket = createWebSocket(_echoUrl);
     });
 
-    tearDown(() async {
-      await webSocket.close();
+    tearDown(() => webSocket?.close());
+
+    test('onOpen should emit single event when the stream opens.', () async {
+      expect(webSocket.onOpen.single, completion(null));
     });
 
-    test('should send and receive data', () async {
+    group('onClose', () {
+      tearDown(() {
+        // prevent tearDown when socket already closed.
+        webSocket = null;
+      });
+
+      test('should emit a single event when the stream closes.', () async {
+        await webSocket.onOpen.single;
+        webSocket.close();
+        expect(webSocket.onClose.single, completion(null));
+      });
+
+      test('should throw a StateError if called after the socket closes',
+          () async {
+        await webSocket.onOpen.single;
+        webSocket.close();
+        await webSocket.onClose.single;
+        expect(webSocket.close(), throwsStateError);
+      });
+    });
+
+    test('should throw a StateError if data is sent after the socket closes',
+        () async {
+      await webSocket.onOpen.single;
+      webSocket.close();
+      await webSocket.onClose.single;
+      expect(webSocket.sendString('hello-world'), throwsStateError);
+      expect(
+          webSocket.sendBytes(new Uint8List(07734).buffer), throwsStateError);
+      // prevent tearDown when socket already closed.
+      webSocket = null;
+    });
+
+    test('sendString should send string data.', () async {
       var payload = 'string data';
-      webSocket.onData.listen(expectAsync((message) {
-        expect(message, payload);
+      await webSocket.onOpen.single;
+      webSocket.onMessage.listen(expectAsync((message) {
+        expect(message.readAsString(), completion(payload));
       }, count: 1));
       webSocket.sendString(payload);
+    });
+
+    test('sendBytes should send byte data.', () async {
+      var payload = new Int8List.fromList([1, 2]);
+      await webSocket.onOpen.single;
+      webSocket.onMessage.listen(expectAsync((message) {
+        message.readAsArrayBuffer().then((ByteBuffer buffer) {
+          expect(buffer.asInt8List(), payload);
+        });
+      }, count: 1));
+      webSocket.sendBytes(payload.buffer);
     });
   });
 }

--- a/tool/presubmit.sh
+++ b/tool/presubmit.sh
@@ -34,6 +34,6 @@ dart bin/socket_echo.dart --port=9095 & export SOCKET_ECHO_PID=$!
 # Run all of our tests
 # If anything fails, we kill the ECHO_PID, otherwise kill at the end.
 echo "Running all tests..."
-pub run test -p "content-shell,vm" || kill $HTTP_ECHO_PID $SOCKET_ECHO_PID
+pub run test -p "dartium,vm" || kill $HTTP_ECHO_PID $SOCKET_ECHO_PID
 kill $HTTP_ECHO_PID $SOCKET_ECHO_PID
 


### PR DESCRIPTION
- Add improved tests for WebSocket
- Make the public interface more consistent with other WebSocket implementations:
  - Change 'onData' to the more commonly understood 'onMessage'
  - Open a websocket on construction instead of using a method call
  - Expose one-shot streams to detect when the socket opens/closes
  - Wrap payloads in SeltzerMessages to give clients more info on received mssages.
