### PR TITLE
use webSocket.done instead of Stream.last to avoid StateError when st…

### DIFF
--- a/lib/platform/server.dart
+++ b/lib/platform/server.dart
@@ -83,7 +83,7 @@ class ServerSeltzerWebSocket implements SeltzerWebSocket {
       if (webSocket.readyState == WebSocket.CLOSED) {
         onCloseCompleter.complete();
       } else {
-        onMessage.last.then((_) => onCloseCompleter.complete());
+        webSocket.done.then((_) => onCloseCompleter.complete());
       }
     });
   }


### PR DESCRIPTION
…ream is empty
