### PR TITLE
Make SeltzerWebSocket delegate to WebSocketChannel

### DIFF
--- a/lib/platform/browser.dart
+++ b/lib/platform/browser.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 import 'package:seltzer/src/context.dart';
 import 'package:seltzer/src/interface.dart';
+import 'package:seltzer/src/socket_impl.dart';
+import 'package:web_socket_channel/html.dart';
 
 export 'package:seltzer/seltzer.dart';
 
@@ -13,7 +15,8 @@ export 'package:seltzer/seltzer.dart';
 /// This is appropriate for clients running in Dartium, DDC, and dart2js.
 void useSeltzerInTheBrowser() {
   setHttpPlatform(const BrowserSeltzerHttp());
-  setSocketPlatform(BrowserSeltzerWebSocket.connect);
+  setSocketPlatform((String url) =>
+      new ChannelWebSocket(new HtmlWebSocketChannel.connect(url)));
 }
 
 /// An implementation of [SeltzerHttp] that works within the browser.
@@ -43,69 +46,5 @@ class BrowserSeltzerHttp extends SeltzerHttp {
               r.response,
               headers: r.responseHeaders,
             ));
-  }
-}
-
-/// A [SeltzerWebSocket] implementation for the browser.
-class BrowserSeltzerWebSocket implements SeltzerWebSocket {
-  /// Connects via web socket to [url].
-  static Future<BrowserSeltzerWebSocket> connect(String url) async {
-    final socket = new WebSocket(url);
-    await socket.onOpen.first;
-    return new BrowserSeltzerWebSocket._(
-      socket,
-    );
-  }
-
-  final WebSocket _webSocket;
-
-  BrowserSeltzerWebSocket._(this._webSocket);
-
-  @override
-  Future<SeltzerSocketClosedEvent> get onClose async {
-    final event = await _webSocket.onClose.first;
-    return new SeltzerSocketClosedEvent(
-      event.code,
-      event.reason,
-    );
-  }
-
-  @override
-  Stream<SeltzerMessage> get onMessage => _webSocket.onMessage.asyncMap((e) {
-        return _decodeSocketMessage(e.data);
-      });
-
-  @override
-  Future<Null> close({int code, String reason}) async {
-    _errorIfClosed();
-    _webSocket.close(code, reason);
-  }
-
-  @override
-  Future<Null> sendString(String data) async {
-    _errorIfClosed();
-    _webSocket.sendString(data);
-  }
-
-  @override
-  Future<Null> sendBytes(ByteBuffer data) async {
-    _errorIfClosed();
-    _webSocket.sendTypedData(data.asInt8List());
-  }
-
-  void _errorIfClosed() {
-    if (_webSocket?.readyState != WebSocket.OPEN) {
-      throw new StateError('Socket is closed.');
-    }
-  }
-}
-
-Future<SeltzerMessage> _decodeSocketMessage(payload) async {
-  if (payload is String) {
-    return new SeltzerMessage.fromString(payload);
-  } else {
-    final reader = new FileReader()..readAsArrayBuffer(payload);
-    await reader.onLoadEnd.first;
-    return new SeltzerMessage.fromBytes(reader.result);
   }
 }

--- a/lib/platform/vm.dart
+++ b/lib/platform/vm.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 import 'package:seltzer/src/context.dart';
 import 'package:seltzer/src/interface.dart';
+import 'package:seltzer/src/socket_impl.dart';
+import 'package:web_socket_channel/io.dart';
 
 export 'package:seltzer/seltzer.dart';
 
@@ -13,7 +15,8 @@ export 'package:seltzer/seltzer.dart';
 /// This is appropriate for clients running in the VM on the command line.
 void useSeltzerInVm() {
   setHttpPlatform(const VmSeltzerHttp());
-  setSocketPlatform(VmSeltzerWebSocket.connect);
+  setSocketPlatform((String url) =>
+      new ChannelWebSocket(new IOWebSocketChannel.connect(url)));
 }
 
 /// An implementation of [SeltzerHttp] implemented via the Dart VM.
@@ -46,84 +49,4 @@ class VmSeltzerHttp extends SeltzerHttp {
       }
     }).asStream();
   }
-}
-
-/// A [SeltzerWebSocket] implementation for the Dart VM.
-class VmSeltzerWebSocket implements SeltzerWebSocket {
-  /// Connects via web socket to [url].
-  static Future<VmSeltzerWebSocket> connect(String url) async {
-    return new VmSeltzerWebSocket._(
-      await WebSocket.connect(url),
-      new Completer<SeltzerSocketClosedEvent>.sync(),
-    );
-  }
-
-  final Completer<SeltzerSocketClosedEvent> _onCloseCompleter;
-  final WebSocket _webSocket;
-
-  VmSeltzerWebSocket._(
-    WebSocket webSocket,
-    Completer<SeltzerSocketClosedEvent> onCloseCompleter,
-  )
-      : onMessage =
-            webSocket.asBroadcastStream().asyncMap(_decodeSocketMessage),
-        _webSocket = webSocket,
-        _onCloseCompleter = onCloseCompleter {
-    onMessage.isEmpty.then((_) {
-      if (webSocket.readyState == WebSocket.CLOSED) {
-        _triggerOnClose();
-      } else {
-        webSocket.done.then((_) => _triggerOnClose());
-      }
-    });
-  }
-
-  void _triggerOnClose() {
-    _onCloseCompleter.complete(
-      new SeltzerSocketClosedEvent(
-        _webSocket.closeCode,
-        _webSocket.closeReason,
-      ),
-    );
-  }
-
-  @override
-  final Stream<SeltzerMessage> onMessage;
-
-  @override
-  Future<SeltzerSocketClosedEvent> get onClose => _onCloseCompleter.future;
-
-  @override
-  Future<Null> close({int code, String reason}) async {
-    _errorIfClosed();
-    _webSocket.close(code, reason);
-  }
-
-  @override
-  Future<Null> sendString(String data) async {
-    _errorIfClosed();
-    _webSocket.add(data);
-  }
-
-  @override
-  Future<Null> sendBytes(ByteBuffer data) async {
-    _errorIfClosed();
-    _webSocket.add(data.asInt8List());
-  }
-
-  void _errorIfClosed() {
-    if (_webSocket.readyState != WebSocket.OPEN) {
-      throw new StateError('Socket is closed.');
-    }
-  }
-}
-
-Future<SeltzerMessage> _decodeSocketMessage(payload) async {
-  if (payload is ByteBuffer) {
-    return new SeltzerMessage.fromBytes(payload.asUint8List());
-  }
-  if (payload is TypedData) {
-    return new SeltzerMessage.fromBytes(payload.buffer.asUint8List());
-  }
-  return new SeltzerMessage.fromString(payload);
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -66,7 +66,7 @@ SeltzerHttp get _seltzer {
 /// Connects to a [web socket](https://tools.ietf.org/html/rfc6455) at [url].
 ///
 /// Uses the currently configured platform configuration.
-Future<SeltzerWebSocket> connect(String url) => _platformSocket(url);
+SeltzerWebSocket connect(String url) => _platformSocket(url);
 
 /// Creates a `DELETE` HTTP request to [url].
 ///

--- a/lib/src/interface/socket.dart
+++ b/lib/src/interface/socket.dart
@@ -3,10 +3,12 @@ import 'dart:typed_data';
 
 import 'package:seltzer/src/context.dart' as platform;
 
+import 'package:seltzer/src/socket_impl.dart';
+import 'package:stream_channel/stream_channel.dart';
 import 'socket_message.dart';
 
 /// Returns a connected [SeltzerWebSocket] to [url].
-typedef Future<SeltzerWebSocket> SeltzerWebSocketProvider(String url);
+typedef SeltzerWebSocket SeltzerWebSocketProvider(String url);
 
 /// A cross-platform [web socket](https://tools.ietf.org/html/rfc6455).
 ///
@@ -23,9 +25,11 @@ abstract class SeltzerWebSocket {
   /// Connects to a web socket server at [url].
   ///
   /// Returns a [Future] that completes upon connecting.
-  static Future<SeltzerWebSocket> connect(String url) => platform.connect(url);
+  static SeltzerWebSocket connect(String url) => platform.connect(url);
 
   /// The stream of data received by this socket.
+  ///
+  /// This is always a broadcast stream.
   Stream<SeltzerMessage> get onMessage;
 
   /// An future that completes when the socket is closed.
@@ -39,13 +43,13 @@ abstract class SeltzerWebSocket {
   ///
   /// Set the optional [code] and [reason] arguments to send close information
   /// to the remote peer.
-  Future<Null> close({int code, String reason});
+  void close({int code, String reason});
 
   /// Sends bytes [data] to the remote peer.
-  Future<Null> sendBytes(ByteBuffer data);
+  void sendBytes(ByteBuffer data);
 
   /// Sends string [data] to the remote peer.
-  Future<Null> sendString(String data);
+  void sendString(String data);
 }
 
 /// Returned from [SeltzerWebSocket.onClose].

--- a/lib/src/socket_impl.dart
+++ b/lib/src/socket_impl.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:async/async.dart';
+import 'package:seltzer/src/interface.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// A cross-platform [SeltzerWebSocket] implementation.
+class ChannelWebSocket implements SeltzerWebSocket {
+  final Completer<SeltzerSocketClosedEvent> _onCloseCompleter =
+      new Completer<SeltzerSocketClosedEvent>();
+  final StreamSplitter<SeltzerMessage> _messageStreamSplitter;
+  final WebSocketChannel _delegate;
+
+  bool _isOpen = true;
+
+  /// Creates a [ChannelWebSocket] that communicates through [channel].
+  ChannelWebSocket(WebSocketChannel channel)
+      : _delegate = channel,
+        _messageStreamSplitter =
+            new StreamSplitter(channel.stream.asyncMap(_decodeSocketMessage)) {
+    _delegate.sink.done.then((_) {
+      _triggerClose();
+    });
+  }
+
+  @override
+  Stream<SeltzerMessage> get onMessage => _messageStreamSplitter.split();
+
+  @override
+  Future<SeltzerSocketClosedEvent> get onClose => _onCloseCompleter.future;
+
+  @override
+  void close({int code, String reason}) {
+    _errorIfClosed();
+    _delegate.sink.close(code, reason);
+  }
+
+  @override
+  void sendBytes(ByteBuffer data) {
+    _errorIfClosed();
+    _delegate.sink.add(data.asInt8List());
+  }
+
+  @override
+  void sendString(String data) {
+    _errorIfClosed();
+    _delegate.sink.add(data);
+  }
+
+  void _errorIfClosed() {
+    if (!_isOpen) {
+      throw new StateError('Socket is closed.');
+    }
+  }
+
+  static Future<SeltzerMessage> _decodeSocketMessage(payload) async {
+    if (payload is ByteBuffer) {
+      return new SeltzerMessage.fromBytes(payload.asUint8List());
+    }
+    if (payload is TypedData) {
+      return new SeltzerMessage.fromBytes(payload.buffer.asUint8List());
+    }
+    return new SeltzerMessage.fromString(payload);
+  }
+
+  void _triggerClose() {
+    if (_isOpen) {
+      _isOpen = false;
+      _onCloseCompleter.complete(
+        new SeltzerSocketClosedEvent(
+          _delegate.closeCode,
+          _delegate.closeReason,
+        ),
+      );
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: seltzer
-version: 0.2.4-alpha
+version: 0.3.0-alpha
 description: An elegant and rich cross-platform HTTP library for Dart.
 authors:
   - Matan Lurey <matanl@google.com>
@@ -13,6 +13,7 @@ dependencies:
   meta: "^1.0.4"
   reply: "0.1.2-dev"
   quiver: "^0.23.0"
+  web_socket_channel: "^1.0.4"
 
 dev_dependencies:
   dart_style: ">=0.2.10"


### PR DESCRIPTION
- Change futures on sendX and close() to void, since Future adds nothing.
- Clean up tests for close()
- major version bump
